### PR TITLE
Undo query planner damage from postgresql cookbook

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,3 +11,5 @@ default['regularroutes']['osm_url'] = 'http://download.geofabrik.de/europe/finla
 default['postgis']['version'] = "2.2"
 default['regularroutes']['reverse_geocoding_uri_template'] = '';
 default['regularroutes']['reverse_geocoding_queries_per_second'] = '';
+default['postgresql']['effective_cache_size'] = '4GB';
+default['postgresql']['work_mem'] = '4MB';


### PR DESCRIPTION
The postgresql cookbook reducing effective_cache_size makes legs
to device_data joining take a 10x slower plan; the reduction in
work_mem adds another 200x. This is somehow unhelpful, so clobber
with upstream default values.

(didn't test a chef run so just delivering as a pull req for a heads-up)