### PR TITLE
Requires=postgresql.service so coming up on reboot is more likely

### DIFF
--- a/files/default/systemd-api.service
+++ b/files/default/systemd-api.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Regularroutes api
+Requires=postgresql.service
 
 [Service]
 Environment=REGULARROUTES_SETTINGS=/opt/regularroutes/regularroutes.cfg

--- a/files/default/systemd-dev.service
+++ b/files/default/systemd-dev.service
@@ -3,6 +3,7 @@
 #
 #[Unit]
 #Description=Regularroutes dev
+#Requires=postgresql.service
 #
 #[Service]
 #Environment=REGULARROUTES_SETTINGS=/opt/regularroutes/regularroutes.cfg

--- a/files/default/systemd-scheduler.service
+++ b/files/default/systemd-scheduler.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Regularroutes scheduler
+Requires=postgresql.service
 
 [Service]
 Environment=REGULARROUTES_SETTINGS=/opt/regularroutes/regularroutes.cfg

--- a/files/default/systemd-site.service
+++ b/files/default/systemd-site.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Regularroutes site
+Requires=postgresql.service
 
 [Service]
 Environment=REGULARROUTES_SETTINGS=/opt/regularroutes/regularroutes.cfg


### PR DESCRIPTION
Noticed rr services didn't survive reboot yesterday, barfs about db not being up as it's starting up concurrently. Added requires, tested stop of db and services and that a rr service start implicitly starts db and doesn't die like that